### PR TITLE
Add overflow-y: scroll for model weight comparisons

### DIFF
--- a/QA-Frontend/static/styles/application.scss
+++ b/QA-Frontend/static/styles/application.scss
@@ -268,6 +268,7 @@ h1 {
   right: 0;
   z-index: 50;
   padding-top: 200px;
+  overflow-y: scroll;
   background-color: rgba(255, 255, 255, 0.85);
 
   .container > h1 {


### PR DESCRIPTION
This allows scrolling when screen size < question height. Otherwise you cannot view the entire comparison.